### PR TITLE
99% Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+pty
+bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# 
+# WARNING
+# THIS MAKEFILE CAN ONLY BE USED TO GENERATE A VERSION OF SSHD-LITE
+# THAT IS BASED ON A PENDING PULL REQUEST OF THE PTY PROJECT
+#
+BUILD_VARS=-s -w
+TRIM_FLAGS=-gcflags "all=-trimpath=${PWD}" -asmflags "all=-trimpath=${PWD}"
+
+pty/go.mod:
+	git clone https://github.com/jeffreystoke/pty.git
+
+all: linux64 linuxarm64 darwin64 darwinarm64 win64
+
+linux: linux64
+
+linux64: pty/go.mod
+	GOOS=linux GOARCH=amd64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/sshd-lite && cd bin && sha256sum sshd-lite > sshd-lite.sha256
+
+linuxarm64: pty/go.mod
+	GOOS=linux GOARCH=arm64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/sshd-lite-arm64  && cd bin && sha256sum sshd-lite-arm64 > sshd-lite-arm64.sha256
+
+darwin64: pty/go.mod
+	GOOS=darwin GOARCH=amd64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/sshd-lite-darwin && cd bin && sha256sum sshd-lite-darwin > sshd-lite-darwin.sha256
+
+darwinarm64: pty/go.mod
+	GOOS=darwin GOARCH=arm64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/sshd-lite-darwin-arm64 && cd bin && sha256sum sshd-lite-darwin-arm64 > sshd-lite-darwin-arm64.sha256
+
+win64: pty/go.mod
+	GOOS=windows GOARCH=amd64 go build ${TRIM_FLAGS} -ldflags "${BUILD_VARS}" -o bin/sshd-lite.exe && cd bin && sha256sum sshd-lite.exe > sshd-lite-win64.sha256
+
+verify:
+	cd bin && sha256sum *.sha256 -c && cd ../;

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/jpillora/sshd-lite
 
 go 1.15
 
+replace github.com/creack/pty => ./pty
+
 require (
 	github.com/creack/pty v1.1.11
 	golang.org/x/crypto v0.0.0-20201116153603-4be66e5b6582

--- a/server/pty_utils.go
+++ b/server/pty_utils.go
@@ -3,8 +3,7 @@ package sshd
 import (
 	"encoding/binary"
 
-	"syscall"
-	"unsafe"
+	"github.com/creack/pty"
 )
 
 // parseDims extracts terminal dimensions (width x height) from the provided buffer.
@@ -14,20 +13,10 @@ func parseDims(b []byte) (uint32, uint32) {
 	return w, h
 }
 
-// ======================
-
-// Winsize stores the Height and Width of a terminal.
-type Winsize struct {
-	Height uint16
-	Width  uint16
-	x      uint16 // unused
-	y      uint16 // unused
-}
-
 // SetWinsize sets the size of the given pty.
-func SetWinsize(fd uintptr, w, h uint32) {
-	ws := &Winsize{Width: uint16(w), Height: uint16(h)}
-	syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
+func SetWinsize(t pty.FdHolder, w, h uint32) {
+	ws := &pty.Winsize{Rows: uint16(h), Cols: uint16(w)}
+	pty.Setsize(t, ws)
 }
 
 // Borrowed from https://github.com/creack/termios/blob/master/win/win.go

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -30,7 +31,11 @@ func NewServer(c *Config) (*Server, error) {
 	s := &Server{c: c, sc: sc}
 
 	if c.Shell == "" {
-		c.Shell = "bash"
+		if runtime.GOOS == "windows" {
+			c.Shell = "powershell"
+		} else {
+			c.Shell = "bash"
+		}
 	}
 	p, err := exec.LookPath(c.Shell)
 	if err != nil {
@@ -261,7 +266,7 @@ func (s *Server) attachShell(connection ssh.Channel, env []string, resizes <-cha
 	go func() {
 		for payload := range resizes {
 			w, h := parseDims(payload)
-			SetWinsize(shellf.Fd(), w, h)
+			SetWinsize(shellf, w, h)
 		}
 	}()
 	//pipe session to shell and visa-versa


### PR DESCRIPTION
As suggested in this thread: https://gist.github.com/jpillora/b480fde82bff51a06238 it is indeed possible to support Windows.

A very interesting pull request, waiting to be integrated in the pty project (find it here: https://github.com/creack/pty/pull/109) offers seamless Windows integration.

Due to this relying on an unmerged upstream pull request, I am not really expecting you to just merge in this pull request and call it a day :)

"And what about the remaining 1%?" you may ask. Well, that remaining 1% is that, while resize et al work well, in order to exit a powershell or cmd session, you will need to hit `ENTER~.` as typing `exit` in powershell does not close the SSH session. In fact, no session request is generated at this time, nor does the pty get EOF. So far, googling the issue has not helped much. I found this related issue when using Cygwin (https://stackoverflow.com/questions/42774454/how-to-exit-powershell-exe-inside-of-cmd) but no solution (I suspect the fix lies somewhere in the ConPTY API, which I am not very familiar with)